### PR TITLE
Address non-binary blocking

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -445,10 +445,9 @@
              </t>
           </list>
 
-        Future specifications of a Captive Portal Signaling Protocol will not provide mechanisms for
-        communicating selective blocking. That is, the protocol will not provide mechanisms to block
-        some portions of the external network, but not others. Note that this does not preclude a
-        captive portal deployment from using a walled garden.
+       The Captive Portal Signaling Protocol does not provide any means of indicating that the
+       network prevents access to some destinations. The intent is to rely on the Captive Portal API
+       and the web portal to which it points to communicate local network policies.
        </t>
        <t>
 	       The Captive Portal Enforcement function SHOULD send Captive Portal Signals when disallowed

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -444,6 +444,11 @@
                 Device and the User Equipment.
              </t>
           </list>
+
+        Future specifications of a Captive Portal Signaling Protocol will not provide mechanisms for
+        communicating selective blocking. That is, the protocol will not provide mechanisms to block
+        some portions of the external network, but not others. Note that this does not preclude a
+        captive portal deployment from using a walled garden.
        </t>
        <t>
 	       The Captive Portal Enforcement function SHOULD send Captive Portal Signals when disallowed


### PR DESCRIPTION
Point out that future Captive Portal Signalling Protocols will not
enable non-binary blocking.

Fixes Issue #13