### PR TITLE
Describe what happens if the portal URI changes

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -737,6 +737,19 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
      </list>
     </t>
     </section>
+    <section title="Handling of Changes in Portal URI">
+    <t>A different Captive Portal API URI could be returned in the following cases:</t>
+    <t>
+      <list style="symbols">
+        <t>If DHCP is used, a lease renewal/rebind may return a different Captive
+          Portal API URI.</t>
+        <t>If RA is used, a new Captive Portal API URI may be specified in a new RA
+          message received by end user equipment.</t>
+      </list>
+    </t>
+    <t>Whenever a new Portal URI is received by end user equipment, it SHOULD discard
+      the old URI and use the new one for future requests to the API.</t>
+    </section>
    </section>
 
    <section anchor="Acknowledgments" title="Acknowledgments">


### PR DESCRIPTION
Just realized that, this section may also apply to the case of initial provisioning of Portal URI if multiple ways are used, such as:
DHCPv4/DHCPv6/RA could be used at the same time, and they return different values;

to quote 7710bis:
   However, if the URIs learned are not in fact all identical the
   captive device MUST prioritize URIs learned from network provisioning
   or configuration mechanisms before all other URIs.  Specifically,
   URIs learned via any of the options in Section 2 should take
   precedence over any URI learned via some other mechanism, such as a
   redirect.

Shall we mention anything on the initial provisioning case too here? or that will only in 7710bis?