### PR TITLE
Remove nuisance from risks

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -800,7 +800,7 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
            ensure the integrity of this information, as well as its confidentiality.
        </t>
      </section>
-     <section title="Risk of Nuisance Captive Portal">
+     <section title="Risks Associated with the Signaling Protocol">
        <t>
          If a Signaling Protocol is implemented, it may be possible for any user on
          the Internet to send signals in attempt to cause the receiving equipment to


### PR DESCRIPTION
This was not phrased well. We decided in Montreal that we should
rephrase the title of the nuisance captive portal in the risks section.

Fixes Issue #24