### PR TITLE
Remove pvd lead-in

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -287,7 +287,6 @@
        </section>
        <section anchor="section_pvd" title="Provisioning Domains">
          <t>
-           Although still a work in progress,
            <xref target="I-D.ietf-intarea-provisioning-domains"/>
            proposes a mechanism for User Equipment to be provided with PvD
            Bootstrap Information containing the URI for a JSON file containing


### PR DESCRIPTION
PvD is almost certainly going to be published first, so remove the
lead-in to it in preparation for integrating the full rfc soon.

Fixes #29 