### PR TITLE
do not imply that the document is a standard

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -105,7 +105,7 @@
        of alerting the user involve modifying HTTP or DNS traffic.
       </t>
       <t>
-       This document standardizes an architecture for implementing captive
+       This document describes an architecture for implementing captive
        portals while addressing most of the problems arising for current
        captive portal mechanisms. The architecture is guided by these
        principles:


### PR DESCRIPTION
The document is informational. We had some language implying that it
intended to be standards-track. Rephrase.

Fixes #74