### PR TITLE
expand RA in the abstract

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -82,9 +82,9 @@
         keywords will be used for the search engine. -->
     <abstract>
       <t>This document describes a captive portal architecture.
-        DHCP or Router Advertisements, an optional signaling protocol, and an HTTP API are used to
-        provide the solution. The role of Provisioning Domains (PvDs) is
-        described.
+        DHCP or Router Advertisements (RAs), an optional signaling protocol,
+        and an HTTP API are used to provide the solution. The role of
+        Provisioning Domains (PvDs) is described.
       </t>
     </abstract>
   </front>


### PR DESCRIPTION
We never defined what RA was. Do so by expanding it to Router
Advertisment in the abstract.

Fixes #81