### PR TITLE
do not restrict provisioning protocols in abstract

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -82,9 +82,9 @@
         keywords will be used for the search engine. -->
     <abstract>
       <t>This document describes a captive portal architecture.
-        DHCP or Router Advertisements (RAs), an optional signaling protocol,
-        and an HTTP API are used to provide the solution. The role of
-        Provisioning Domains (PvDs) is described.
+        Network provisioning protocols such as DHCP or Router Advertisements (RAs),
+        an optional signaling protocol, and an HTTP API are used to provide the solution.
+        The role of Provisioning Domains (PvDs) is described.
       </t>
     </abstract>
   </front>


### PR DESCRIPTION
Open up the abstract's wording a bit so we make it clear that other
provisioning protocols could be used in the future for discovering the
API URI.

Fixes #87 