### PR TITLE
recommend that the user portal uri be https

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -315,7 +315,9 @@
         </t>
         <t>
          At minimum, the API MUST provide the state of captivity. Further the
-         API MUST be able to provide a URI for the User Portal.
+         API MUST be able to provide a URI for the User Portal. The scheme for
+         the URI SHOULD be https so that the User Equipment communicates with
+         the User Portal over TLS.
         </t>
          <t>
          A caller to the API needs to be presented with evidence that the content

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -316,7 +316,7 @@
         <t>
          At minimum, the API MUST provide the state of captivity. Further the
          API MUST be able to provide a URI for the User Portal. The scheme for
-         the URI SHOULD be https so that the User Equipment communicates with
+         the URI MUST be https so that the User Equipment communicates with
          the User Portal over TLS.
         </t>
          <t>


### PR DESCRIPTION
We never talked about TLS for the user portal. Add a bit of language
related to that.

Fixes #90

To discuss:
 - Should this be a MUST? Existing solutions often don't use https, but that may not be a good reason to loosen the requirement.
 - Have I properly mentioned the URI scheme as being https? Do we even need to do that? I'm trying to put a requirement on the API that it provide a URI that lends itself to tls-based communication, which is why I took that approach.