### PR TITLE
update component diagram to mention optional visit

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -389,7 +389,10 @@
       <section>
         <name>Component Diagram</name>
         <t>
-            The following diagram shows the communication between each component.
+            The following diagram shows the communication between each component in the
+            case where the Captive Network has a User Portal, and the User Equipment
+            chooses to visit the User Portal in response to discovering and interacting
+            with the API Server.
         </t>
         <figure anchor="components">
           <name>Captive Portal Architecture Component Diagram</name>


### PR DESCRIPTION
Whether or not the user visits the User Portal is optional: the user
could choose not to, or the Captive Portal may not provide one. Clarify
that the case presented in the component diagram is the one where the
User Portal is present, and where the user chooses to visit it.

Fixes #94 