### PR TITLE
define session in terminology

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -214,12 +214,14 @@
           communicating Captive Portal Signals.
         </t>
         <t>
-          Captive Portal Session: Also known as "session". A Captive Portal Session is the assocation
-          of a User Equipment to its state of captivity in the Captive Network. We say that a session
-          starts when the User Equipment associates with the Captive Network. We say that a session ends
-          when the association ends, or when the User Equipment no longer satisfies the Captive Portal
-          Conditions after previously satisfying them. Typically the Captive Network components determine the
-          User Equipment's session using the User Equipment's identifier (see <xref target="ue_identity"/>). 
+        Captive Portal Session: Also referred to simply as the “session”, a Captive Portal
+        Session is the association for a particular User Equipment that starts when it
+        interacts with the Captive Portal and gains open access to the network, and ends
+        when the User Equipment moves back into the original captive state. The Captive
+        Network maintains the state of each active Session, and can limit Sessions based
+        on a length of time or a number of bytes used. The Session is associated with a
+        particular User Equipment using the User Equipment's identifier (see
+        <xref target="ue_identity"/>).
         </t>
       </section>
     </section>

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -213,6 +213,14 @@
         <t>Captive Portal Signaling Protocol: Also known as Signaling Protocol. The protocol for
           communicating Captive Portal Signals.
         </t>
+        <t>
+          Captive Portal Session: Also known as "session". A Captive Portal Session is the assocation
+          of a User Equipment to its state of captivity in the Captive Network. We say that a session
+          starts when the User Equipment associates with the Captive Network. We say that a session ends
+          when the association ends, or when the User Equipment no longer satisfies the Captive Portal
+          Conditions after previously satisfying them. Typically the Captive Network components determine the
+          User Equipment's session using the User Equipment's identifier (see <xref target="ue_identity"/>). 
+        </t>
       </section>
     </section>
     <section>


### PR DESCRIPTION
The idea of a session is important, both because it is used in the API
document, and because it helps to tie everything together. Define it in
the terminology.

Fixes #92 