### PR TITLE
Mention escaping captivity in api def

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -203,7 +203,7 @@
           captivity.</t>
         <t>Captive Portal API: Also known as API. An HTTP API allowing User Equipment
           to query information about its state of captivity within the Captive Portal. This
-          information might include how to escape captivity (e.g. by visting a URI).
+          information might include how to obtain full network access (e.g. by visting a URI).
         </t>
         <t>Captive Portal API Server: Also known as API Server. A server hosting the
           Captive Portal API.

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -202,7 +202,8 @@
           assisting the user in satisfying the conditions to escape
           captivity.</t>
         <t>Captive Portal API: Also known as API. An HTTP API allowing User Equipment
-          to query its state of captivity within the Captive Portal.
+          to query information about its state of captivity within the Captive Portal. This
+          information might include how to escape captivity (e.g. by visting a URI).
         </t>
         <t>Captive Portal API Server: Also known as API Server. A server hosting the
           Captive Portal API.


### PR DESCRIPTION
The API provides more than just a simple boolean sttate: it allows the
UE to learn how to escape captivity. To set the tone for a more
complicated API, mention this in the terminology section's definition of
the Captive Portal API.

Fixes #93