### PR TITLE
Mention signal-flooding attack mitigation

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -380,7 +380,7 @@
         updated information.  For instance, this signal might be generated when the end of a
         session is imminent, or when network access was denied.
         For simplicity, and to reduce the attack surface, all signals SHOULD be considered
-        equivalent by the User Equipment, as a hint to contact the API.
+        equivalent by the User Equipment: as a hint to contact the API.
         If future solutions have multiple signal types, each type SHOULD be rate-limited
         independently.
         </t>

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -845,7 +845,7 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
               carry any information which may mislead or misdirect the User Equipment.</li>
           <li>Even when responding to the signal, the User Equipment securely authenticates
                with API Servers.</li>
-          <li>Accesses to the Captive Portal API are rate limited, limiting the impact of an
+          <li>Accesses to the Captive Portal API are rate limited, reducing the impact of an
               attack attempting to generate excessive load on either User Equipment or API.
               Note that because there is only one type of signal and one type of API request in
               response to the signal, this rate-limiting will not cause loss of signalling

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -381,6 +381,8 @@
         session is imminent, or when network access was denied.
         For simplicity, and to reduce the attack surface, all signals SHOULD be considered
         equivalent by the User Equipment, as a hint to contact the API.
+        If future solutions have multiple signal types, each type SHOULD be rate-limited
+        independently.
         </t>
 
         <t>
@@ -845,7 +847,7 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
               carry any information which may mislead or misdirect the User Equipment.</li>
           <li>Even when responding to the signal, the User Equipment securely authenticates
                with API Servers.</li>
-          <li>Accesses to the Captive Portal API are rate limited, reducing the impact of an
+          <li>Accesses to the Captive Portal API are rate-limited, reducing the impact of an
               attack attempting to generate excessive load on either User Equipment or API.
               Note that because there is only one type of signal and one type of API request in
               response to the signal, this rate-limiting will not cause loss of signalling

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -379,6 +379,8 @@
         indicates that the User Equipment might need to contact the API Server to receive
         updated information.  For instance, this signal might be generated when the end of a
         session is imminent, or when network access was denied.
+        For simplicity, and to reduce the attack surface, all signals SHOULD be considered
+        equivalent by the User Equipment, as a hint to contact the API.
         </t>
 
         <t>
@@ -843,8 +845,10 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
               carry any information which may mislead or misdirect the User Equipment.</li>
           <li>Even when responding to the signal, the User Equipment securely authenticates
                with API Servers.</li>
-          <li>Accesses to the API Server are rate limited, limiting the impact of a repeated
-              attack.</li>
+          <li>Accesses to the Captive Portal API are rate limited, limiting the impact of a
+              repeated attack. Because there is only one type of signal and one type of API
+              request in response to the signal, a signal-flooding attack will not obscure
+              information from the API to the User Equipment.</li>
         </ul>
       </section>
       <section>

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -845,10 +845,12 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
               carry any information which may mislead or misdirect the User Equipment.</li>
           <li>Even when responding to the signal, the User Equipment securely authenticates
                with API Servers.</li>
-          <li>Accesses to the Captive Portal API are rate limited, limiting the impact of a
-              repeated attack. Because there is only one type of signal and one type of API
-              request in response to the signal, a signal-flooding attack will not obscure
-              information from the API to the User Equipment.</li>
+          <li>Accesses to the Captive Portal API are rate limited, limiting the impact of an
+              attack attempting to generate excessive load on either User Equipment or API.
+              Note that because there is only one type of signal and one type of API request in
+              response to the signal, this rate-limiting will not cause loss of signalling
+              information.
+              </li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
New SHOULD requirement to consider all signals as a single simple hint.
Fixes issue #102

Looking for reviewers to confirm this new SHOULD is OK.