### PR TITLE
expand tls use in section 7.2

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -841,9 +841,8 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
         <name>Authenticated APIs</name>
         <t>
          The solution described here requires that when the User Equipment needs to
-         access the API server, server authentication will be performed using TLS
-         mechanisms. See <xref target="section_client"/> for a description of how
-         the User Equipment performs the authentiation procedure.
+         access the API server, the User Equipment authenticates the 
+         server; see <xref target="section_client"/>.
         </t>
         <t>
          The Captive Portal API URI might change during the Captive Portal Session.

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -840,9 +840,10 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
       <section>
         <name>Authenticated APIs</name>
         <t>
-         The solution described here assumes that when the User Equipment needs to
-         trust the API server, server authentication will be performed using TLS
-         mechanisms.
+         The solution described here requires that when the User Equipment needs to
+         access the API server, server authentication will be performed using TLS
+         mechanisms. See <xref target="section_client"/> for a description of how
+         the User Equipment performs the authentiation procedure.
         </t>
         <t>
          The Captive Portal API URI might change during the Captive Portal Session.


### PR DESCRIPTION
A reviewer pointed out that we need to specify how TLS is used. Link to
the existing procedure in the User Equipment requirements. Also rephrase
so that it doesn't sound like we're suggestion that using TLS is
optional.

Fixes #100