### PR TITLE
replace normative language in 3.1

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -522,9 +522,9 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
                  An Identifier is a characteristic of the User Equipment used by
                  the components of a Captive Portal to uniquely determine which
                  specific User Equipment is interacting with them.
-                 An Identifier MAY be a field contained in packets
+                 An Identifier can be a field contained in packets
                  sent by the User Equipment to the External Network. Or, an
-                 Identifier MAY be an ephemeral property not contained in packets
+                 Identifier can be an ephemeral property not contained in packets
                  destined for the External Network, but instead correlated with
                  such information through knowledge available to the different
                  components.


### PR DESCRIPTION
We were unnecessarily using normative language in section 3.1. Replace
it with non-normative language.

Fixes #112