### PR TITLE
remove normative MAY from section 2.1

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -180,7 +180,7 @@
             it could be captive.
             In response, the device MAY query the provisioned API to obtain
             information about the network state.
-            The device MAY take immediate action to satisfy the portal
+            The device can take immediate action to satisfy the portal
             (according to its configuration/policy).
          </li>
       </ul>


### PR DESCRIPTION
We didn't need this. Replace it with can.

Fixes #116