### PR TITLE
Include UE joining network in figure 1

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -443,11 +443,12 @@
           <artwork><![CDATA[
 o . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . o
 . CAPTIVE NETWORK                                               .
-.                                            +--------------+   .
-. +------------+   Provision API URI         | Provisioning |   .
-. |            |<---------------------------+|  Service     |   .
+. +------------+  Join Network               +--------------+   .
+. |            |+--------------------------->| Provisioning |   .
+. |            |  Provision API URI          |  Service     |   .
+. |            |<---------------------------+|              |   .
 . |   User     |                             +--------------+   .
-. | Equipment  |   Query captivity status    +-------------+    .
+. | Equipment  |  Query captivity status     +-------------+    .
 . |            |+--------------------------->|  API        |    .
 . |            |  Captivity status response  |  Server     |    .
 . |            |<---------------------------+|             |    .
@@ -463,7 +464,7 @@ o . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . o
 .     |   | +-----------------> +---------------+  Allow/Deny   .
 .     |   +--------------------+|               |    Rules      .
 .     |                         | Enforcement   |     |         .
-.     |   Captive Portal Signal | Device        | <---+         .
+.     |   Captive Portal Signal | Device        |<----+         .
 .     +-------------------------+---------------+               .
 .                                      ^ |                      .
 .                                      | |                      .
@@ -478,8 +479,8 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
         In the diagram:
         </t>
         <ul spacing="normal">
-          <li>During provisioning (e.g., DHCP), the User Equipment acquires
-                 the Captive Portal API URI.</li>
+          <li>During provisioning (e.g., DHCP), and possibly later, the User
+              Equipment acquires the Captive Portal API URI.</li>
           <li>The User Equipment queries the API to learn of its state of
                  captivity. If captive, the User Equipment presents the portal
                  user interface from the User Portal to the user.</li>


### PR DESCRIPTION
A reviewer pointed out that the diagram made it look like the
provisioning service triggers the entire process, whereas the UE joining
the network is what does so. Add a Join Network interaction to the
diagram.

Fixes #113 