### PR TITLE
use consistent terminology for signalling

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -168,16 +168,14 @@
             A device MAY query this API at any time to determine whether the
             network is holding the device in a captive state.
          </li>
-        <li>End-user devices can be signalled that they could be captive with Captive Portal
-            Signals in response to traffic. This signal works in response
-            to any Internet protocol, and is not done by modifying protocols
-            in-band.  This signal does not carry the Captive Portal API URI; rather
-            it provides a signal to the User Equipment that it is in a
-            captive state.
+        <li>A Captive Network can signal User Equipment in response to transmissions by
+            the User Equipment. This signal works in response to any Internet protocol,
+            and is not done by modifying protocols in-band.  This signal does not carry the
+            Captive Portal API URI; rather it provides a signal to the User Equipment that it
+            is in a captive state.
         </li>
         <li>
-            Receipt of a Captive Portal Signal provides a hint that an end-user device could be captive.
-            it could be captive.
+            Receipt of a Captive Portal Signal provides a hint that User Equipment could be captive.
             In response, the device MAY query the provisioned API to obtain
             information about the network state.
             The device can take immediate action to satisfy the portal

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -168,15 +168,15 @@
             A device MAY query this API at any time to determine whether the
             network is holding the device in a captive state.
          </li>
-        <li>End-user devices can be notified of captivity with Captive Portal
-            Signals in response to traffic. This notification works in response
+        <li>End-user devices can be signalled that they could be captive with Captive Portal
+            Signals in response to traffic. This signal works in response
             to any Internet protocol, and is not done by modifying protocols
-            in-band.  This notification does not carry the Captive Portal API URI; rather
-            it provides a notification to the User Equipment that it is in a
+            in-band.  This signal does not carry the Captive Portal API URI; rather
+            it provides a signal to the User Equipment that it is in a
             captive state.
         </li>
         <li>
-            Receipt of a Captive Portal Signal informs an end-user device that
+            Receipt of a Captive Portal Signal signals to an end-user device that
             it could be captive.
             In response, the device MAY query the provisioned API to obtain
             information about the network state.
@@ -221,7 +221,7 @@
         <t>Captive Portal API Server: Also known as API Server. A server hosting the
           Captive Portal API.
         </t>
-        <t>Captive Portal Signal: A notification from the network used to inform the User Equipment
+        <t>Captive Portal Signal: A notification from the network used to signal to the User Equipment
           that the state of its captivity could have changed.
         </t>
         <t>Captive Portal Signaling Protocol: Also known as Signaling Protocol. The protocol for
@@ -909,7 +909,7 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
          address it in the following ways:
         </t>
         <ul spacing="normal">
-          <li>The signal only informs the User Equipment to query the API. It does not
+          <li>The signal only signals to the User Equipment to query the API. It does not
               carry any information which may mislead or misdirect the User Equipment.</li>
           <li>Even when responding to the signal, the User Equipment securely authenticates
                with API Servers.</li>
@@ -924,7 +924,7 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
       <section>
         <name>User Options</name>
         <t>
-         The Captive Portal Signal could inform the User Equipment that it is being held
+         The Captive Portal Signal could signal to the User Equipment that it is being held
          captive.  There is no requirement that the User Equipment do something
          about this.
          Devices MAY permit users to disable automatic reaction to

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -176,7 +176,7 @@
             captive state.
         </li>
         <li>
-            Receipt of a Captive Portal Signal signals to an end-user device that
+            Receipt of a Captive Portal Signal provides a hint that an end-user device could be captive.
             it could be captive.
             In response, the device MAY query the provisioned API to obtain
             information about the network state.


### PR DESCRIPTION
A reviewer pointed out that we used notifying, informing, signalling, and
alerting to mean the same thing: sending the Captive Portal Signal. I've
chosen to use signal as the verb of choice.

The phrasing seems a bit awkward in a few places, so I'm not 100% confident in my choice here.

Fixes #111