### PR TITLE
add a privacy section

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -944,15 +944,15 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
         <name>Privacy</name>
         <t>
           <xref target="ue_identity"/> describes a mechanism by which all components within
-          the Captive Network agree on a unique identifier for the User Equipment.
-          This identifier could be abused to track the user. Implementers and designers
-          of Captive Networks should take care to ensure that identifiers, if stored, are
-          stored securely. Likewise, if any component communicates the identifier over the
-          network, it should ensure the confidentiality of the identifier on the wire by
-          using encryption such as TLS.
+          the Captive Portal are designed to use the same identifier to uniquely identify
+          the User Equipment.  This identifier could be abused to track the user.
+          Implementers and designers of Captive Portals should take care to ensure that
+          identifiers, if stored, are stored securely. Likewise, if any component
+          communicates the identifier over the network, it should ensure the confidentiality
+          of the identifier on the wire by using encryption such as TLS.
         </t>
         <t>
-          The fact that an identity can change provides some anonymity benefits. For
+          There are benfits to choosing mutable anonymous identifiers. For
           example, User Equipment could cycle through multiple identifiers to help prevent
           long-term tracking. However, if the components of the network use an internal
           mapping to map the identity to a stable, long-term value in order to deal with

--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -940,6 +940,27 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
          Domains.
         </t>
       </section>
+      <section>
+        <name>Privacy</name>
+        <t>
+          <xref target="ue_identity"/> describes a mechanism by which all components within
+          the Captive Network agree on a unique identifier for the User Equipment.
+          This identifier could be abused to track the user. Implementers and designers
+          of Captive Networks should take care to ensure that identifiers, if stored, are
+          stored securely. Likewise, if any component communicates the identifier over the
+          network, it should ensure the confidentiality of the identifier on the wire by
+          using encryption such as TLS.
+        </t>
+        <t>
+          The fact that an identity can change provides some anonymity benefits. For
+          example, User Equipment could cycle through multiple identifiers to help prevent
+          long-term tracking. However, if the components of the network use an internal
+          mapping to map the identity to a stable, long-term value in order to deal with
+          changing identifiers, they need to treat that value as sensitive information: an
+          attacker could use it to tie traffic back to the originating User Equipment,
+          despite the User Equipment having changed identifiers.
+        </t>
+      </section>
     </section>
   </middle>
   <!--  *****BACK MATTER ***** -->


### PR DESCRIPTION
This adds a privacy section which discusses the implications of the User
Equipment identity.

I'm open to suggestions for more content here. Some thoughts:
 - State that may not contain the identity, but can be mapped to from it?
 - Logging?

Fixes #109