### PR TITLE
replace Captive Network with Captive Portal

### DIFF
--- a/draft-ietf-capport-architecture.xml
+++ b/draft-ietf-capport-architecture.xml
@@ -168,7 +168,7 @@
             A device MAY query this API at any time to determine whether the
             network is holding the device in a captive state.
          </li>
-        <li>A Captive Network can signal User Equipment in response to transmissions by
+        <li>A Captive Portal can signal User Equipment in response to transmissions by
             the User Equipment. This signal works in response to any Internet protocol,
             and is not done by modifying protocols in-band.  This signal does not carry the
             Captive Portal API URI; rather it provides a signal to the User Equipment that it
@@ -198,7 +198,7 @@
       </section>
       <section>
         <name>Terminology</name>
-        <t>Captive Network: A network which limits communication of attached
+        <t>Captive Portal: A network which limits communication of attached
           devices to restricted hosts until the user has satisfied
           Captive Portal Conditions, after which access is permitted to a wider
           set of hosts (typically the Internet).</t>
@@ -294,7 +294,7 @@
         </t>
         <t>
         The User Equipment can store the last response it received from the Captive Portal API
-        as a cached view of its state within the Captive Network. This state can be used to
+        as a cached view of its state within the Captive Portal. This state can be used to
         determine whether its Captive Portal Session is near expiry. For example, the User
         Equipment might compare a timestamp indicating when the session expires to the current
         time. Storing state in this way can reduce the need for communication with the
@@ -310,7 +310,7 @@
           Portal API URI to the User Equipment when it connects to the network, and
           later if the URI changes.  The provisioning service could also be the same
           service which is responsible for provisioning the User Equipment for
-          access to the Captive Network (e.g., by providing it with an IP address).
+          access to the Captive Portal (e.g., by providing it with an IP address).
           This section discusses two mechanisms which may be used to provide the
           Captive Portal API URI to the User Equipment.
         </t>
@@ -438,7 +438,7 @@
         <name>Component Diagram</name>
         <t>
             The following diagram shows the communication between each component in the
-            case where the Captive Network has a User Portal, and the User Equipment
+            case where the Captive Portal has a User Portal, and the User Equipment
             chooses to visit the User Portal in response to discovering and interacting
             with the API Server.
         </t>
@@ -446,7 +446,7 @@
           <name>Captive Portal Architecture Component Diagram</name>
           <artwork><![CDATA[
 o . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . o
-. CAPTIVE NETWORK                                               .
+. CAPTIVE PORTAL                                                .
 . +------------+  Join Network               +--------------+   .
 . |            |+--------------------------->| Provisioning |   .
 . |            |  Provision API URI          |  Service     |   .
@@ -560,9 +560,9 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
         <section anchor="id_recommended_unique">
           <name>Uniquely Identify User Equipment</name>
           <t>
-                  The Captive Network MUST associate the User Equipment with an
+                  The Captive Portal MUST associate the User Equipment with an
                   identifier that is unique among the User Equipment that are
-                  interacting with the Captive Network at that time.
+                  interacting with the Captive Portal at that time.
           </t>
           <t>
                   Over time, the User Equipment assigned to an identifier value MAY change. Allowing the
@@ -763,15 +763,15 @@ o . . . . . . . . . . . . . . . . . . .| |. . . . . . . . . . . o
         <name>Initial Connection</name>
         <t>
       This section describes a possible workflow when User Equipment initially
-      joins a Captive Network.
+      joins a Captive Portal.
         </t>
         <ol spacing="normal" type="1">
-          <li>The User Equipment joins the Captive Network by acquiring a DHCP
+          <li>The User Equipment joins the Captive Portal by acquiring a DHCP
          lease, RA, or similar, acquiring provisioning information.</li>
           <li>The User Equipment learns the URI for the Captive Portal API from the
          provisioning information (e.g., <xref target="RFC7710bis"/>).</li>
           <li>The User Equipment accesses the Captive Portal API to receive parameters
-         of the Captive Network, including User Portal URI. (This step replaces
+         of the Captive Portal, including User Portal URI. (This step replaces
          the clear-text query to a canary URI.)</li>
           <li>If necessary, the User navigates to the User Portal to gain access to the
          external network.</li>


### PR DESCRIPTION
A reviewer pointed out that Captive Portal and Captive Network were used
interchangeably in the document. While we used Captive Network more
frequently, Captive Portal aligns more closely with familiar use of the
term. Further, other documents such as the API draft refer to the system
as a whole as a Captive Portal, which makes this change more aligned
with them.


Fixes #72 